### PR TITLE
Render reports using vertical format because they're too wide

### DIFF
--- a/bin/reports.sh
+++ b/bin/reports.sh
@@ -39,7 +39,7 @@ function run_query() {
         $container_name \
         trino --catalog hive --schema v2 \
         -f "/tmp/$(basename "$file")" \
-        --output-format=ALIGNED | ansi2html --inline --unescape
+        --output-format=VERTICAL | ansi2html --inline --unescape
 }
 
 GITHUB_SERVER_URL=${GITHUB_SERVER_URL:-https://github.com}

--- a/sql/git/achievements.sql
+++ b/sql/git/achievements.sql
@@ -34,7 +34,7 @@ SELECT
   min_by(a.achieved_in, a.achieved_at) AS first_achieved_in,
   slice(array_agg(a.fullname ORDER BY a.num_achieved DESC, a.achieved_at) FILTER (WHERE year(a.achieved_at) = year(current_date)), 1, 3) AS recent_top3,
   slice(array_agg(a.fullname ORDER BY a.num_achieved DESC, a.achieved_at), 1, 3) AS alltime_top3,
-  format('<img src="aches/%s.png" title="%s" />', acha.id, acha.name) AS icon
+  format('<img src="aches/%s@6x.png" title="%s" />', acha.id, acha.name) AS icon
 FROM acha
 LEFT JOIN masked a ON a.id = acha.id
 CROSS JOIN (SELECT COUNT(*) AS idents_count FROM memory.default.idents) i

--- a/sql/git/achievements.sql
+++ b/sql/git/achievements.sql
@@ -39,5 +39,5 @@ FROM acha
 LEFT JOIN masked a ON a.id = acha.id
 CROSS JOIN (SELECT COUNT(*) AS idents_count FROM memory.default.idents) i
 GROUP BY acha.id, acha.name, acha.description, i.idents_count
-ORDER BY NULLIF(num_winners, 0) NULLS LAST, acha.name
+ORDER BY NULLIF(num_winners, 0) DESC NULLS LAST, acha.name
 ;

--- a/sql/git/winners.sql
+++ b/sql/git/winners.sql
@@ -26,7 +26,7 @@ WITH acha AS (
     count(acq.id) AS num_achievements,
     array_join(transform(
                    zip(array_agg(acq.id), array_agg(acq.name), array_agg(acq.achieved_at), array_agg(acq.achieved_in)),
-                   ac -> format('<img src="aches/%s.png" title="%s - achieved on %s in commit %s" />', ac[1], ac[2], ac[3], ac[4])), ' ', '') AS achievements
+                   ac -> format('<img src="aches/%s@6x.png" title="%s - achieved on %s in commit %s" />', ac[1], ac[2], ac[3], ac[4])), ' ', '') AS achievements
   FROM acq
   GROUP BY acq.author_name)
 SELECT


### PR DESCRIPTION
Render reports using vertical format because they're too wide

Order achievements by num_winners in descending order